### PR TITLE
Add bugfix for detecting Linux directories in Windows

### DIFF
--- a/Scripts/tests.py
+++ b/Scripts/tests.py
@@ -54,6 +54,8 @@ def run_is_dir_tests() -> bool:
         (os.sep, True),
         (os.path.join(os.sep, "dir", "file.txt"), False),
         (os.path.join(os.sep, "dir", "dir2" + os.sep), True),
+        # often directories in DReyeVR are labeled with '/' sep
+        (os.path.join("testing", "linuxsep/"), True),
     ]
     for name, expected in name_and_exp:
         if advanced_is_dir(name) != expected:

--- a/Scripts/utils.py
+++ b/Scripts/utils.py
@@ -188,7 +188,7 @@ def advanced_is_dir(name: str) -> bool:
     # if not, we'll need to just analyze the string itself
     # check if the last character is the os separator
     # https://docs.python.org/3/library/os.html#os.sep
-    return name[-1] == os.sep
+    return name[-1] == os.sep or name[-1] == "/"  # check OS sep or linux sep
 
 
 def advanced_create(


### PR DESCRIPTION
Add bugfix for #27 tested on Windows. 

Issue arose when the Content had not been installed yet and `make install` was invoked, then since the directories in our Paths.csv file are denoted as Linux directories (separated by `/`) the script thought we were installing to a file instead of a directory. 