### PR TITLE
Add minor bugfixes and feature improvements

### DIFF
--- a/Carla/Actor/DReyeVRCustomActor.cpp
+++ b/Carla/Actor/DReyeVRCustomActor.cpp
@@ -49,6 +49,12 @@ ADReyeVRCustomActor::ADReyeVRCustomActor(const FObjectInitializer &ObjectInitial
     Internals.Scale3D = this->GetActorScale3D();
 }
 
+ADReyeVRCustomActor::~ADReyeVRCustomActor()
+{
+    this->Deactivate();
+    this->Destroy(); // UE4 Destroy method
+}
+
 bool ADReyeVRCustomActor::AssignSM(const FString &Path, UWorld *World)
 {
     UStaticMesh *SM = LoadObject<UStaticMesh>(nullptr, *Path);
@@ -99,7 +105,7 @@ void ADReyeVRCustomActor::Initialize(const FString &Name)
 {
     Internals.Name = Name;
     ADReyeVRCustomActor::ActiveCustomActors[TCHAR_TO_UTF8(*Name)] = this;
-    UE_LOG(LogTemp, Log, TEXT("Initialized custom actor: %s"), *Name);
+    // UE_LOG(LogTemp, Log, TEXT("Initialized custom actor: %s"), *Name);
 }
 
 void ADReyeVRCustomActor::BeginPlay()

--- a/Carla/Actor/DReyeVRCustomActor.h
+++ b/Carla/Actor/DReyeVRCustomActor.h
@@ -23,6 +23,9 @@ class CARLA_API ADReyeVRCustomActor : public AActor // abstract class
     GENERATED_BODY()
 
   public:
+    ADReyeVRCustomActor(const FObjectInitializer &ObjectInitializer);
+    ~ADReyeVRCustomActor();
+
     /// factory function to create a new instance of a given type
     static ADReyeVRCustomActor *CreateNew(const FString &SM_Path, const FString &Mat_Path, UWorld *World,
                                           const FString &Name);
@@ -49,7 +52,6 @@ class CARLA_API ADReyeVRCustomActor : public AActor // abstract class
     struct DReyeVR::CustomActorData::MaterialParamsStruct MaterialParams;
 
   private:
-    ADReyeVRCustomActor(const FObjectInitializer &ObjectInitializer);
     void BeginPlay() override;
     void BeginDestroy() override;
     bool bIsActive = false; // initially deactivated

--- a/Carla/Sensor/DReyeVRSensor.cpp
+++ b/Carla/Sensor/DReyeVRSensor.cpp
@@ -86,7 +86,7 @@ void ADReyeVRSensor::PostPhysTick(UWorld *W, ELevelTick TickType, float DeltaSec
         };
         carla::geom::Vector3D operator()(const FRotator &In)
         {
-            return carla::geom::Vector3D{In.Pitch, In.Roll, In.Yaw};
+            return carla::geom::Vector3D{In.Pitch, In.Yaw, In.Roll};
         };
         carla::geom::Vector2D operator()(const FVector2D &In)
         {

--- a/Carla/Sensor/DReyeVRSensor.h
+++ b/Carla/Sensor/DReyeVRSensor.h
@@ -41,7 +41,7 @@ class CARLA_API ADReyeVRSensor : public ASensor
     const class DReyeVR::AggregateData *GetData() const
     {
         // read-only variant of GetData
-        return ADReyeVRSensor::Data;
+        return const_cast<const class DReyeVR::AggregateData *>(ADReyeVRSensor::Data);
     }
 
     bool IsReplaying() const;

--- a/Carla/Vehicle/CarlaWheeledVehicle.cpp
+++ b/Carla/Vehicle/CarlaWheeledVehicle.cpp
@@ -265,7 +265,7 @@ void ACarlaWheeledVehicle::OnOverlapBegin(UPrimitiveComponent *OverlappedComp, A
   if (OtherActor != nullptr && OtherActor != this)
   {
     FString actor_name = OtherActor->GetName();
-    UE_LOG(LogTemp, Log, TEXT("Collision with \"%s\""), *actor_name);
+    // UE_LOG(LogTemp, Log, TEXT("Collision with \"%s\""), *actor_name);
     // can be more flexible, such as having collisions with static props or people too
     const FString OtherName = OtherActor->GetName().ToLower();
     double Now = FPlatformTime::Seconds();

--- a/Configs/DReyeVRConfig.ini
+++ b/Configs/DReyeVRConfig.ini
@@ -89,13 +89,13 @@ ScaleMouseY=1.0
 ScaleMouseX=1.0
 
 [EgoVehicleHUD]
-HUDScaleVR=6; scale all  HUD elements in VR mode only
+HUDScaleVR=6; scale all HUD elements in VR mode only
 DrawFPSCounter=True; draw's FPS (frames per second) in top right corner of flat screen
 DrawFlatReticle=True; reticle in flat-screen mode
 DrawGaze=False; draw debug gaze lines on flat-screen hud
 DrawSpectatorReticle=True; reticle in spectator mode during vr (VR spectator HUD only)
 ReticleSize=100; diameter of reticle (thickness also scales)
-EnableSpectatorScreen=True; don't spent time rendering the spectator screen
+EnableSpectatorScreen=True; whether or not to enable the flat-screen spectator when in VR
 
 [Level]
 EgoVolumePercent=100
@@ -103,10 +103,10 @@ NonEgoVolumePercent=100
 AmbientVolumePercent=20
 
 [Replayer]
-CameraFollowHMD=False; Whether or not to have the camera pose follow the recorded HMD pose
+CameraFollowHMD=True; Whether or not to have the camera pose follow the recorded HMD pose
 RunSyncReplay=True; Whether or not to run the replayer exactly frame by frame (no interpolation)
-RecordAllShaders=True; Enable or disable rendering the scene with additional (beyond RGB) shaders such as depth
-RecordAllPoses=True; Enable or disable rendering the scene with all camera poses (beyond driver's seat)
+RecordAllShaders=False; Enable or disable rendering the scene with additional (beyond RGB) shaders such as depth
+RecordAllPoses=False; Enable or disable rendering the scene with all camera poses (beyond driver's seat)
 RecordFrames=True; additionally capture camera screenshots on replay tick (requires RunSyncReplay=True)
 FileFormatJPG=True; either JPG or PNG
 LinearGamma=True; force linear gamme for frame capture render

--- a/DReyeVR/DReyeVRPawn.cpp
+++ b/DReyeVR/DReyeVRPawn.cpp
@@ -207,15 +207,24 @@ void ADReyeVRPawn::DrawSpectatorScreen(const FVector &GazeOrigin, const FVector 
         // define min and max bounds (where the texture is actually drawn on screen)
         const FVector2D TextureRectMin = ReticlePos / ViewSize;                 // top left
         const FVector2D TextureRectMax = (ReticlePos + ReticleSize) / ViewSize; // bottom right
-        UHeadMountedDisplayFunctionLibrary::SetSpectatorScreenModeTexturePlusEyeLayout(
-            FVector2D{0.f, 0.f}, // whole window (top left)
-            FVector2D{1.f, 1.f}, // whole window (top -> bottom right)
-            TextureRectMin,      // top left of texture
-            TextureRectMax,      // bottom right of texture
-            true,                // draw eye data as background
-            false,               // clear w/ black
-            true                 // use alpha
-        );
+        auto Within01 = [](const float Num) { return 0.f <= Num && Num <= 1.f; };
+        bool RectMinValid = Within01(TextureRectMin.X) && Within01(TextureRectMin.Y);
+        bool RectMaxValid = Within01(TextureRectMax.X) && Within01(TextureRectMax.Y);
+        const FVector2D WindowTopLeft{0.f, 0.f};     // top left of screen
+        const FVector2D WindowBottomRight{1.f, 1.f}; // bottom right of screen
+        if (RectMinValid && RectMaxValid)
+        {
+            /// TODO: disable the texture when RectMin or RectMax is invalid
+            UHeadMountedDisplayFunctionLibrary::SetSpectatorScreenModeTexturePlusEyeLayout(
+                WindowTopLeft,     // whole window (top left)
+                WindowBottomRight, // whole window (top -> bottom right)
+                TextureRectMin,    // top left of texture
+                TextureRectMax,    // bottom right of texture
+                true,              // draw eye data as background
+                false,             // clear w/ black
+                true               // use alpha
+            );
+        }
     }
 }
 

--- a/DReyeVR/EgoSensor.h
+++ b/DReyeVR/EgoSensor.h
@@ -47,6 +47,7 @@ class CARLAUE4_API AEgoSensor : public ADReyeVRSensor
 
     // function where replayer requests a screenshot
     void TakeScreenshot() override;
+    bool ComputeGazeTrace(FHitResult &Hit, const ECollisionChannel TraceChannel, float TraceRadius = 0.f) const;
 
   protected:
     void BeginPlay();
@@ -63,6 +64,7 @@ class CARLAUE4_API AEgoSensor : public ADReyeVRSensor
     void DestroyEyeTracker();
     void ComputeDummyEyeData(); // when no hardware sensor is present
     void TickEyeTracker();      // tick hardware sensor
+    void ComputeFocusInfo();
     void ComputeTraceFocusInfo(const ECollisionChannel TraceChannel, float TraceRadius = 0.f);
     float MaxTraceLenM = 100.f;        // maximum trace length in m
     bool bDrawDebugFocusTrace = false; // draw the trace ray and hit point or not

--- a/DReyeVR/EgoVehicle.cpp
+++ b/DReyeVR/EgoVehicle.cpp
@@ -1,7 +1,7 @@
 #include "EgoVehicle.h"
 #include "Carla/Actor/ActorAttribute.h"             // FActorAttribute
 #include "Carla/Actor/ActorRegistry.h"              // Register
-#include "Carla/Game/CarlaStatics.h"                // GetEpisode
+#include "Carla/Game/CarlaStatics.h"                // GetCurrentEpisode
 #include "Carla/Vehicle/CarlaWheeledVehicleState.h" // ECarlaWheeledVehicleState
 #include "DReyeVRPawn.h"                            // ADReyeVRPawn
 #include "DrawDebugHelpers.h"                       // Debug Line/Sphere
@@ -93,9 +93,6 @@ void AEgoVehicle::BeginPlay()
     World = GetWorld();
     Episode = UCarlaStatics::GetCurrentEpisode(World);
 
-    // Spawn and attach the EgoSensor
-    InitSensor();
-
     // initialize
     InitAIPlayer();
 
@@ -122,11 +119,11 @@ void AEgoVehicle::Tick(float DeltaSeconds)
 {
     Super::Tick(DeltaSeconds);
 
-    // Update the positions based off replay data
-    ReplayTick();
-
     // Get the current data from the AEgoSensor and use it
     UpdateSensor(DeltaSeconds);
+
+    // Update the positions based off replay data
+    ReplayTick();
 
     // Draw debug lines on editor
     DebugLines();
@@ -274,6 +271,10 @@ FRotator AEgoVehicle::GetCameraRot() const
 {
     return GetCamera()->GetComponentRotation();
 }
+const class AEgoSensor *AEgoVehicle::GetSensor() const
+{
+    return const_cast<const class AEgoSensor *>(EgoSensor);
+}
 
 /// ========================================== ///
 /// ---------------:AIPLAYER:----------------- ///
@@ -312,6 +313,9 @@ void AEgoVehicle::TickAutopilot()
 
 void AEgoVehicle::InitSensor()
 {
+    // update the world on refresh (ex. --reloadWorld)
+    World = GetWorld();
+    check(World != nullptr);
     // Spawn the EyeTracker Carla sensor and attach to Ego-Vehicle:
     FActorSpawnParameters EyeTrackerSpawnInfo;
     EyeTrackerSpawnInfo.Owner = this;
@@ -371,6 +375,20 @@ void AEgoVehicle::ReplayTick()
 
 void AEgoVehicle::UpdateSensor(const float DeltaSeconds)
 {
+    if (EgoSensor == nullptr) // Spawn and attach the EgoSensor
+    {
+        // unfortunately World->SpawnActor *sometimes* fails if used in BeginPlay so
+        // calling it once in the tick is fine to avoid this crash.
+        InitSensor();
+    }
+
+    ensure(EgoSensor != nullptr);
+    if (EgoSensor == nullptr)
+    {
+        UE_LOG(LogTemp, Warning, TEXT("EgoSensor initialization failed!"));
+        return;
+    }
+
     // Explicitly update the EgoSensor here, synchronized with EgoVehicle tick
     EgoSensor->ManualTick(DeltaSeconds); // Ensures we always get the latest data
 

--- a/DReyeVR/EgoVehicle.h
+++ b/DReyeVR/EgoVehicle.h
@@ -53,6 +53,7 @@ class CARLAUE4_API AEgoVehicle : public ACarlaWheeledVehicle
     const UCameraComponent *GetCamera() const;
     UCameraComponent *GetCamera();
     const DReyeVR::UserInputs &GetVehicleInputs() const;
+    const class AEgoSensor *GetSensor() const;
 
     // autopilot API
     void SetAutopilot(const bool AutopilotOn);

--- a/DReyeVR/LevelScript.cpp
+++ b/DReyeVR/LevelScript.cpp
@@ -1,5 +1,5 @@
 #include "LevelScript.h"
-#include "Carla/Game/CarlaStatics.h"           // UCarlaStatics::GetRecorder
+#include "Carla/Game/CarlaStatics.h"           // GetRecorder, GetEpisode
 #include "Carla/Sensor/DReyeVRSensor.h"        // ADReyeVRSensor
 #include "Carla/Vehicle/CarlaWheeledVehicle.h" // ACarlaWheeledVehicle
 #include "Components/AudioComponent.h"         // UAudioComponent

--- a/Docs/Install.md
+++ b/Docs/Install.md
@@ -195,8 +195,8 @@ Before installing `DReyeVR`, we'll also need to install the dependencies:
       which python3
       ...
       > PATH/TO/ANACONDA/envs/carla/bin/python3 # example output
-      # go to carla/include dir from here
-      cd PATH/TO/ANACONDA/envs/carla/include
+      # go to carla/install dir from here
+      cd PATH/TO/ANACONDA/envs/carla/install
       # create a symlink between python3.7 -> python3.7m
       ln -s python3.7m python3.7
       ```

--- a/LibCarla/Sensor/SensorRegistry.h
+++ b/LibCarla/Sensor/SensorRegistry.h
@@ -1,0 +1,106 @@
+// Copyright (c) 2019 Computer Vision Center (CVC) at the Universitat Autonoma
+// de Barcelona (UAB).
+//
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#ifndef LIBCARLA_SENSOR_REGISTRY_INCLUDE_H
+#define LIBCARLA_SENSOR_REGISTRY_INCLUDE_H
+
+#include "carla/sensor/CompositeSerializer.h"
+
+// =============================================================================
+// Follow the 4 steps to register a new sensor.
+// =============================================================================
+
+// 1. Include the serializer here.
+#include "carla/sensor/s11n/CollisionEventSerializer.h"
+#include "carla/sensor/s11n/DVSEventArraySerializer.h"
+#include "carla/sensor/s11n/EpisodeStateSerializer.h"
+#include "carla/sensor/s11n/GnssSerializer.h"
+#include "carla/sensor/s11n/ImageSerializer.h"
+#include "carla/sensor/s11n/OpticalFlowImageSerializer.h"
+#include "carla/sensor/s11n/IMUSerializer.h"
+#include "carla/sensor/s11n/LidarSerializer.h"
+#include "carla/sensor/s11n/NoopSerializer.h"
+#include "carla/sensor/s11n/ObstacleDetectionEventSerializer.h"
+#include "carla/sensor/s11n/RadarSerializer.h"
+#include "carla/sensor/s11n/SemanticLidarSerializer.h"
+#include "carla/sensor/s11n/DReyeVRSerializer.h" // DReyeVR serializer header
+
+// 2. Add a forward-declaration of the sensor here.
+class ACollisionSensor;
+class ADepthCamera;
+class ADVSCamera;
+class AGnssSensor;
+class AInertialMeasurementUnit;
+class ALaneInvasionSensor;
+class AObstacleDetectionSensor;
+class AOpticalFlowCamera;
+class ARadar;
+class ARayCastSemanticLidar;
+class ARayCastLidar;
+class ASceneCaptureCamera;
+class ASemanticSegmentationCamera;
+class AInstanceSegmentationCamera;
+class ARssSensor;
+class FWorldObserver;
+class ADReyeVRSensor; // DReyeVR forward declaration
+
+namespace carla {
+namespace sensor {
+
+  // 3. Register the sensor and its serializer in the SensorRegistry.
+
+  /// Contains a registry of all the sensors available and allows serializing
+  /// and deserializing sensor data for the types registered.
+  ///
+  /// Use s11n::NoopSerializer if the sensor does not send data (sensors that
+  /// work only on client-side).
+  using SensorRegistry = CompositeSerializer<
+    std::pair<ACollisionSensor *, s11n::CollisionEventSerializer>,
+    std::pair<ADepthCamera *, s11n::ImageSerializer>,
+    std::pair<ADVSCamera *, s11n::DVSEventArraySerializer>,
+    std::pair<AGnssSensor *, s11n::GnssSerializer>,
+    std::pair<AInertialMeasurementUnit *, s11n::IMUSerializer>,
+    std::pair<ALaneInvasionSensor *, s11n::NoopSerializer>,
+    std::pair<AObstacleDetectionSensor *, s11n::ObstacleDetectionEventSerializer>,
+    std::pair<AOpticalFlowCamera *, s11n::OpticalFlowImageSerializer>,
+    std::pair<ARadar *, s11n::RadarSerializer>,
+    std::pair<ARayCastSemanticLidar *, s11n::SemanticLidarSerializer>,
+    std::pair<ARayCastLidar *, s11n::LidarSerializer>,
+    std::pair<ARssSensor *, s11n::NoopSerializer>,
+    std::pair<ASceneCaptureCamera *, s11n::ImageSerializer>,
+    std::pair<ASemanticSegmentationCamera *, s11n::ImageSerializer>,
+    std::pair<AInstanceSegmentationCamera *, s11n::ImageSerializer>,
+    std::pair<FWorldObserver *, s11n::EpisodeStateSerializer>,
+    std::pair<ADReyeVRSensor *, s11n::DReyeVRSerializer>
+  >;
+
+} // namespace sensor
+} // namespace carla
+
+#endif // LIBCARLA_SENSOR_REGISTRY_INCLUDE_H
+
+#ifdef LIBCARLA_SENSOR_REGISTRY_WITH_SENSOR_INCLUDES
+
+// 4. Include the sensor here.
+#include "Carla/Sensor/CollisionSensor.h"
+#include "Carla/Sensor/DepthCamera.h"
+#include "Carla/Sensor/DVSCamera.h"
+#include "Carla/Sensor/GnssSensor.h"
+#include "Carla/Sensor/InertialMeasurementUnit.h"
+#include "Carla/Sensor/LaneInvasionSensor.h"
+#include "Carla/Sensor/ObstacleDetectionSensor.h"
+#include "Carla/Sensor/OpticalFlowCamera.h"
+#include "Carla/Sensor/Radar.h"
+#include "Carla/Sensor/RayCastLidar.h"
+#include "Carla/Sensor/RayCastSemanticLidar.h"
+#include "Carla/Sensor/RssSensor.h"
+#include "Carla/Sensor/SceneCaptureCamera.h"
+#include "Carla/Sensor/SemanticSegmentationCamera.h"
+#include "Carla/Sensor/InstanceSegmentationCamera.h"
+#include "Carla/Sensor/WorldObserver.h"
+#include "Carla/Sensor/DReyeVRSensor.h" // DReyeVRSensor header file
+
+#endif // LIBCARLA_SENSOR_REGISTRY_WITH_SENSOR_INCLUDES

--- a/PythonAPI/DReyeVR_utils.py
+++ b/PythonAPI/DReyeVR_utils.py
@@ -38,7 +38,7 @@ def find_ego_sensor(world: carla.libcarla.World) -> Optional[carla.libcarla.Sens
     try:
         sensor = ego_sensors[0]  # TODO: support for multiple eye trackers?
     except IndexError:
-        print("Unable to find DReyeVR ego vehicle in world!")
+        print("Unable to find DReyeVR ego sensor in world!")
     return sensor
 
 

--- a/PythonAPI/libcarla/SensorData.cpp
+++ b/PythonAPI/libcarla/SensorData.cpp
@@ -1,0 +1,619 @@
+// Copyright (c) 2017 Computer Vision Center (CVC) at the Universitat Autonoma
+// de Barcelona (UAB).
+//
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#include <carla/PythonUtil.h>
+#include <carla/image/ImageConverter.h>
+#include <carla/image/ImageIO.h>
+#include <carla/image/ImageView.h>
+#include <carla/pointcloud/PointCloudIO.h>
+#include <carla/sensor/SensorData.h>
+#include <carla/sensor/data/CollisionEvent.h>
+#include <carla/sensor/data/IMUMeasurement.h>
+#include <carla/sensor/data/ObstacleDetectionEvent.h>
+#include <carla/sensor/data/Image.h>
+#include <carla/sensor/data/LaneInvasionEvent.h>
+#include <carla/sensor/data/LidarMeasurement.h>
+#include <carla/sensor/data/SemanticLidarMeasurement.h>
+#include <carla/sensor/data/GnssMeasurement.h>
+#include <carla/sensor/data/RadarMeasurement.h>
+#include <carla/sensor/data/DVSEventArray.h>
+#include <carla/sensor/data/DReyeVREvent.h> // DReyeVR sensor event
+
+#include <carla/sensor/data/RadarData.h>
+
+#include <boost/python/suite/indexing/vector_indexing_suite.hpp>
+
+#include <ostream>
+#include <iostream>
+#include <cmath>
+#include <vector>
+#include <algorithm>
+#include <thread>
+
+namespace carla {
+namespace sensor {
+namespace data {
+
+  std::ostream &operator<<(std::ostream &out, const Image &image) {
+    out << "Image(frame=" << std::to_string(image.GetFrame())
+        << ", timestamp=" << std::to_string(image.GetTimestamp())
+        << ", size=" << std::to_string(image.GetWidth()) << 'x' << std::to_string(image.GetHeight())
+        << ')';
+    return out;
+  }
+
+  std::ostream &operator<<(std::ostream &out, const OpticalFlowImage &image) {
+    out << "OpticalFlowImage(frame=" << std::to_string(image.GetFrame())
+        << ", timestamp=" << std::to_string(image.GetTimestamp())
+        << ", size=" << std::to_string(image.GetWidth()) << 'x' << std::to_string(image.GetHeight())
+        << ')';
+    return out;
+  }
+
+  std::ostream &operator<<(std::ostream &out, const LidarMeasurement &meas) {
+    out << "LidarMeasurement(frame=" << std::to_string(meas.GetFrame())
+        << ", timestamp=" << std::to_string(meas.GetTimestamp())
+        << ", number_of_points=" << std::to_string(meas.size())
+        << ')';
+    return out;
+  }
+
+  std::ostream &operator<<(std::ostream &out, const SemanticLidarMeasurement &meas) {
+    out << "SemanticLidarMeasurement(frame=" << std::to_string(meas.GetFrame())
+        << ", timestamp=" << std::to_string(meas.GetTimestamp())
+        << ", number_of_points=" << std::to_string(meas.size())
+        << ')';
+    return out;
+  }
+
+  std::ostream &operator<<(std::ostream &out, const CollisionEvent &meas) {
+    out << "CollisionEvent(frame=" << std::to_string(meas.GetFrame())
+        << ", timestamp=" << std::to_string(meas.GetTimestamp())
+        << ", other_actor=" << meas.GetOtherActor()
+        << ')';
+    return out;
+  }
+
+  std::ostream &operator<<(std::ostream &out, const ObstacleDetectionEvent &meas) {
+    out << "ObstacleDetectionEvent(frame=" << std::to_string(meas.GetFrame())
+        << ", timestamp=" << std::to_string(meas.GetTimestamp())
+        << ", other_actor=" << meas.GetOtherActor()
+        << ')';
+    return out;
+  }
+
+  std::ostream &operator<<(std::ostream &out, const LaneInvasionEvent &meas) {
+    out << "LaneInvasionEvent(frame=" << std::to_string(meas.GetFrame())
+        << ", timestamp=" << std::to_string(meas.GetTimestamp())
+        << ')';
+    return out;
+  }
+
+  std::ostream &operator<<(std::ostream &out, const GnssMeasurement &meas) {
+    out << "GnssMeasurement(frame=" << std::to_string(meas.GetFrame())
+        << ", timestamp=" << std::to_string(meas.GetTimestamp())
+        << ", lat=" << std::to_string(meas.GetLatitude())
+        << ", lon=" << std::to_string(meas.GetLongitude())
+        << ", alt=" << std::to_string(meas.GetAltitude())
+        << ')';
+    return out;
+  }
+
+  std::ostream &operator<<(std::ostream &out, const IMUMeasurement &meas) {
+    out << "IMUMeasurement(frame=" << std::to_string(meas.GetFrame())
+        << ", timestamp=" << std::to_string(meas.GetTimestamp())
+        << ", accelerometer=" << meas.GetAccelerometer()
+        << ", gyroscope=" << meas.GetGyroscope()
+        << ", compass=" << std::to_string(meas.GetCompass())
+        << ')';
+    return out;
+  }
+
+  std::ostream &operator<<(std::ostream &out, const RadarMeasurement &meas) {
+    out << "RadarMeasurement(frame=" << std::to_string(meas.GetFrame())
+        << ", timestamp=" << std::to_string(meas.GetTimestamp())
+        << ", point_count=" << std::to_string(meas.GetDetectionAmount())
+        << ')';
+    return out;
+  }
+
+  std::ostream &operator<<(std::ostream &out, const DVSEvent &event) {
+    out << "Event(x=" << std::to_string(event.x)
+        << ", y=" << std::to_string(event.y)
+        << ", t=" << std::to_string(event.t)
+        << ", pol=" << std::to_string(event.pol) << ')';
+    return out;
+  }
+
+  std::ostream &operator<<(std::ostream &out, const DVSEventArray &events) {
+    out << "EventArray(frame=" << std::to_string(events.GetFrame())
+        << ", timestamp=" << std::to_string(events.GetTimestamp())
+        << ", dimensions=" << std::to_string(events.GetWidth()) << 'x' << std::to_string(events.GetHeight())
+        << ", number_of_events=" << std::to_string(events.size())
+        << ')';
+    return out;
+  }
+
+
+  std::ostream &operator<<(std::ostream &out, const RadarDetection &det) {
+    out << "RadarDetection(velocity=" << std::to_string(det.velocity)
+        << ", azimuth=" << std::to_string(det.azimuth)
+        << ", altitude=" << std::to_string(det.altitude)
+        << ", depth=" << std::to_string(det.depth)
+        << ')';
+    return out;
+  }
+
+  std::ostream &operator<<(std::ostream &out, const LidarDetection &det) {
+    out << "LidarDetection(x=" << std::to_string(det.point.x)
+        << ", y=" << std::to_string(det.point.y)
+        << ", z=" << std::to_string(det.point.z)
+        << ", intensity=" << std::to_string(det.intensity)
+        << ')';
+    return out;
+  }
+
+  std::ostream &operator<<(std::ostream &out, const SemanticLidarDetection &det) {
+    out << "SemanticLidarDetection(x=" << std::to_string(det.point.x)
+        << ", y=" << std::to_string(det.point.y)
+        << ", z=" << std::to_string(det.point.z)
+        << ", cos_inc_angle=" << std::to_string(det.cos_inc_angle)
+        << ", object_idx=" << std::to_string(det.object_idx)
+        << ", object_tag=" << std::to_string(det.object_tag)
+        << ')';
+    return out;
+  }
+
+  std::ostream &operator<<(std::ostream &out, const DReyeVREvent &event) {
+    // what is used when printing the data streamed to the PythonAPI (converting to string)
+    auto &GazeDir = event.GetGazeDir();
+    auto &GazeOrigin = event.GetGazeOrigin();
+    auto &CameraLocn = event.GetCameraLocation();
+    auto &CameraRotn = event.GetCameraRotation();
+    const std::string sep = ", ";
+    out << "DReyeVR(frame=" << event.GetFrame() << sep
+        << "t=" << event.GetTimestamp() << sep
+        << "GazeDir(" << event.GetGazeValid() << ")={" << GazeDir.x << ", " << GazeDir.y << ", " << GazeDir.z<< "}" << sep
+        << "GazeOrigin={" << GazeOrigin.x << ", " << GazeOrigin.y << ", " << GazeOrigin.z << "}" << sep
+        << "Vergence=" << event.GetGazeVergence() << sep
+        << "CameraLoc={" << CameraLocn.x << ", " << CameraLocn.y << ", " << CameraLocn.z<< "}" << sep
+        << "CameraRot={" << CameraRotn.x << ", " << CameraRotn.y << ", " << CameraRotn.z<< "}" << sep
+        << ')';
+    return out;
+  }
+} // namespace s11n
+} // namespace sensor
+} // namespace carla
+
+enum class EColorConverter {
+  Raw,
+  Depth,
+  LogarithmicDepth,
+  CityScapesPalette
+};
+
+template <typename T>
+static auto GetRawDataAsBuffer(T &self) {
+  auto *data = reinterpret_cast<unsigned char *>(self.data());
+  auto size = static_cast<Py_ssize_t>(sizeof(typename T::value_type) * self.size());
+#if PY_MAJOR_VERSION >= 3
+  auto *ptr = PyMemoryView_FromMemory(reinterpret_cast<char *>(data), size, PyBUF_READ);
+#else
+  auto *ptr = PyBuffer_FromMemory(data, size);
+#endif
+  return boost::python::object(boost::python::handle<>(ptr));
+}
+
+template <typename T>
+static void ConvertImage(T &self, EColorConverter cc) {
+  carla::PythonUtil::ReleaseGIL unlock;
+  using namespace carla::image;
+  auto view = ImageView::MakeView(self);
+  switch (cc) {
+    case EColorConverter::Depth:
+      ImageConverter::ConvertInPlace(view, ColorConverter::Depth());
+      break;
+    case EColorConverter::LogarithmicDepth:
+      ImageConverter::ConvertInPlace(view, ColorConverter::LogarithmicDepth());
+      break;
+    case EColorConverter::CityScapesPalette:
+      ImageConverter::ConvertInPlace(view, ColorConverter::CityScapesPalette());
+      break;
+    case EColorConverter::Raw:
+      break; // ignore.
+    default:
+      throw std::invalid_argument("invalid color converter!");
+  }
+}
+
+// image object resturned from optical flow to color conversion
+class FakeImage : public std::vector<uint8_t> {
+  public:
+  unsigned int Width = 0;
+  unsigned int Height = 0;
+  float FOV = 0;
+};
+// method to convert optical flow images to rgb
+static FakeImage ColorCodedFlow (
+    carla::sensor::data::OpticalFlowImage& image) {
+  namespace bp = boost::python;
+  namespace csd = carla::sensor::data;
+  constexpr float pi = 3.1415f;
+  constexpr float rad2ang = 360.f/(2.f*pi);
+  FakeImage result;
+  result.Width = image.GetWidth();
+  result.Height = image.GetHeight();
+  result.FOV = image.GetFOVAngle();
+  result.resize(image.GetHeight()*image.GetWidth()* 4);
+
+  // lambda for computing batches of pixels
+  auto command = [&] (size_t min_index, size_t max_index) {
+    for (size_t index = min_index; index < max_index; index++) {
+      const csd::OpticalFlowPixel& pixel = image[index];
+      float vx = pixel.x;
+      float vy = pixel.y;
+
+      float angle = 180.f + std::atan2(vy, vx)*rad2ang;
+      if (angle < 0) angle = 360.f + angle;
+      angle = std::fmod(angle, 360.f);
+
+      float norm = std::sqrt(vx*vx + vy*vy);
+      const float shift = 0.999f;
+      const float a = 1.f/std::log(0.1f + shift);
+      float intensity = carla::geom::Math::Clamp(a*std::log(norm + shift), 0.f, 1.f);
+
+      float& H = angle;
+      float  S = 1.f;
+      float V = intensity;
+      float H_60 = H*(1.f/60.f);
+
+      float C = V * S;
+      float X = C*(1.f - std::abs(std::fmod(H_60, 2.f) - 1.f));
+      float m = V - C;
+
+      float r = 0,g = 0,b = 0;
+      unsigned int angle_case = static_cast<unsigned int>(H_60);
+      switch (angle_case) {
+      case 0:
+        r = C;
+        g = X;
+        b = 0;
+        break;
+      case 1:
+        r = X;
+        g = C;
+        b = 0;
+        break;
+      case 2:
+        r = 0;
+        g = C;
+        b = X;
+        break;
+      case 3:
+        r = 0;
+        g = X;
+        b = C;
+        break;
+      case 4:
+        r = X;
+        g = 0;
+        b = C;
+        break;
+      case 5:
+        r = C;
+        g = 0;
+        b = X;
+        break;
+      default:
+        r = 1;
+        g = 1;
+        b = 1;
+        break;
+      }
+
+      uint8_t R = static_cast<uint8_t>((r+m)*255.f);
+      uint8_t G = static_cast<uint8_t>((g+m)*255.f);
+      uint8_t B = static_cast<uint8_t>((b+m)*255.f);
+      result[4*index] = B;
+      result[4*index + 1] = G;
+      result[4*index + 2] = R;
+      result[4*index + 3] = 0;
+    }
+  };
+  size_t num_threads = std::max(8u, std::thread::hardware_concurrency());
+  size_t batch_size = image.size() / num_threads;
+  std::vector<std::thread*> t(num_threads+1);
+
+  for(size_t n = 0; n < num_threads; n++) {
+    t[n] = new std::thread(command, n * batch_size, (n+1) * batch_size);
+  }
+  t[num_threads] = new std::thread(command, num_threads * batch_size, image.size());
+
+  for(size_t n = 0; n <= num_threads; n++) {
+    if(t[n]->joinable()){
+      t[n]->join();
+    }
+    delete t[n];
+  }
+  return result;
+}
+
+template <typename T>
+static std::string SaveImageToDisk(T &self, std::string path, EColorConverter cc) {
+  carla::PythonUtil::ReleaseGIL unlock;
+  using namespace carla::image;
+  auto view = ImageView::MakeView(self);
+  switch (cc) {
+    case EColorConverter::Raw:
+      return ImageIO::WriteView(
+          std::move(path),
+          view);
+    case EColorConverter::Depth:
+      return ImageIO::WriteView(
+          std::move(path),
+          ImageView::MakeColorConvertedView(view, ColorConverter::Depth()));
+    case EColorConverter::LogarithmicDepth:
+      return ImageIO::WriteView(
+          std::move(path),
+          ImageView::MakeColorConvertedView(view, ColorConverter::LogarithmicDepth()));
+    case EColorConverter::CityScapesPalette:
+      return ImageIO::WriteView(
+          std::move(path),
+          ImageView::MakeColorConvertedView(view, ColorConverter::CityScapesPalette()));
+    default:
+      throw std::invalid_argument("invalid color converter!");
+  }
+}
+
+template <typename T>
+static std::string SavePointCloudToDisk(T &self, std::string path) {
+  carla::PythonUtil::ReleaseGIL unlock;
+  return carla::pointcloud::PointCloudIO::SaveToDisk(std::move(path), self.begin(), self.end());
+}
+
+void export_sensor_data() {
+  using namespace boost::python;
+  namespace cc = carla::client;
+  namespace cr = carla::rpc;
+  namespace cs = carla::sensor;
+  namespace csd = carla::sensor::data;
+  namespace css = carla::sensor::s11n;
+
+  // Fake image returned from optical flow to color conversion
+  // fakes the regular image object. Only used for visual purposes
+  class_<FakeImage>("FakeImage", no_init)
+      .def(vector_indexing_suite<std::vector<uint8_t>>())
+      .add_property("width", &FakeImage::Width)
+      .add_property("height", &FakeImage::Height)
+      .add_property("fov", &FakeImage::FOV)
+      .add_property("raw_data", &GetRawDataAsBuffer<FakeImage>);
+
+  class_<cs::SensorData, boost::noncopyable, boost::shared_ptr<cs::SensorData>>("SensorData", no_init)
+    .add_property("frame", &cs::SensorData::GetFrame)
+    .add_property("frame_number", &cs::SensorData::GetFrame) // deprecated.
+    .add_property("timestamp", &cs::SensorData::GetTimestamp)
+    .add_property("transform", CALL_RETURNING_COPY(cs::SensorData, GetSensorTransform))
+  ;
+
+  enum_<EColorConverter>("ColorConverter")
+    .value("Raw", EColorConverter::Raw)
+    .value("Depth", EColorConverter::Depth)
+    .value("LogarithmicDepth", EColorConverter::LogarithmicDepth)
+    .value("CityScapesPalette", EColorConverter::CityScapesPalette)
+  ;
+
+  class_<csd::Image, bases<cs::SensorData>, boost::noncopyable, boost::shared_ptr<csd::Image>>("Image", no_init)
+    .add_property("width", &csd::Image::GetWidth)
+    .add_property("height", &csd::Image::GetHeight)
+    .add_property("fov", &csd::Image::GetFOVAngle)
+    .add_property("raw_data", &GetRawDataAsBuffer<csd::Image>)
+    .def("convert", &ConvertImage<csd::Image>, (arg("color_converter")))
+    .def("save_to_disk", &SaveImageToDisk<csd::Image>, (arg("path"), arg("color_converter")=EColorConverter::Raw))
+    .def("__len__", &csd::Image::size)
+    .def("__iter__", iterator<csd::Image>())
+    .def("__getitem__", +[](const csd::Image &self, size_t pos) -> csd::Color {
+      return self.at(pos);
+    })
+    .def("__setitem__", +[](csd::Image &self, size_t pos, csd::Color color) {
+      self.at(pos) = color;
+    })
+    .def(self_ns::str(self_ns::self))
+  ;
+
+  class_<csd::OpticalFlowImage, bases<cs::SensorData>, boost::noncopyable, boost::shared_ptr<csd::OpticalFlowImage>>("OpticalFlowImage", no_init)
+    .add_property("width", &csd::OpticalFlowImage::GetWidth)
+    .add_property("height", &csd::OpticalFlowImage::GetHeight)
+    .add_property("fov", &csd::OpticalFlowImage::GetFOVAngle)
+    .add_property("raw_data", &GetRawDataAsBuffer<csd::OpticalFlowImage>)
+    .def("get_color_coded_flow", &ColorCodedFlow)
+    .def("__len__", &csd::OpticalFlowImage::size)
+    .def("__iter__", iterator<csd::OpticalFlowImage>())
+    .def("__getitem__", +[](const csd::OpticalFlowImage &self, size_t pos) -> csd::OpticalFlowPixel {
+      return self.at(pos);
+    })
+    .def("__setitem__", +[](csd::OpticalFlowImage &self, size_t pos, csd::OpticalFlowPixel color) {
+      self.at(pos) = color;
+    })
+    .def(self_ns::str(self_ns::self))
+  ;
+
+  class_<csd::LidarMeasurement, bases<cs::SensorData>, boost::noncopyable, boost::shared_ptr<csd::LidarMeasurement>>("LidarMeasurement", no_init)
+    .add_property("horizontal_angle", &csd::LidarMeasurement::GetHorizontalAngle)
+    .add_property("channels", &csd::LidarMeasurement::GetChannelCount)
+    .add_property("raw_data", &GetRawDataAsBuffer<csd::LidarMeasurement>)
+    .def("get_point_count", &csd::LidarMeasurement::GetPointCount, (arg("channel")))
+    .def("save_to_disk", &SavePointCloudToDisk<csd::LidarMeasurement>, (arg("path")))
+    .def("__len__", &csd::LidarMeasurement::size)
+    .def("__iter__", iterator<csd::LidarMeasurement>())
+    .def("__getitem__", +[](const csd::LidarMeasurement &self, size_t pos) -> csd::LidarDetection {
+      return self.at(pos);
+    })
+    .def("__setitem__", +[](csd::LidarMeasurement &self, size_t pos, const csd::LidarDetection &detection) {
+      self.at(pos) = detection;
+    })
+    .def(self_ns::str(self_ns::self))
+  ;
+
+  class_<csd::SemanticLidarMeasurement, bases<cs::SensorData>, boost::noncopyable, boost::shared_ptr<csd::SemanticLidarMeasurement>>("SemanticLidarMeasurement", no_init)
+    .add_property("horizontal_angle", &csd::SemanticLidarMeasurement::GetHorizontalAngle)
+    .add_property("channels", &csd::SemanticLidarMeasurement::GetChannelCount)
+    .add_property("raw_data", &GetRawDataAsBuffer<csd::SemanticLidarMeasurement>)
+    .def("get_point_count", &csd::SemanticLidarMeasurement::GetPointCount, (arg("channel")))
+    .def("save_to_disk", &SavePointCloudToDisk<csd::SemanticLidarMeasurement>, (arg("path")))
+    .def("__len__", &csd::SemanticLidarMeasurement::size)
+    .def("__iter__", iterator<csd::SemanticLidarMeasurement>())
+    .def("__getitem__", +[](const csd::SemanticLidarMeasurement &self, size_t pos) -> csd::SemanticLidarDetection {
+      return self.at(pos);
+    })
+    .def("__setitem__", +[](csd::SemanticLidarMeasurement &self, size_t pos, const csd::SemanticLidarDetection &detection) {
+      self.at(pos) = detection;
+    })
+    .def(self_ns::str(self_ns::self))
+  ;
+
+  class_<csd::CollisionEvent, bases<cs::SensorData>, boost::noncopyable, boost::shared_ptr<csd::CollisionEvent>>("CollisionEvent", no_init)
+    .add_property("actor", &csd::CollisionEvent::GetActor)
+    .add_property("other_actor", &csd::CollisionEvent::GetOtherActor)
+    .add_property("normal_impulse", CALL_RETURNING_COPY(csd::CollisionEvent, GetNormalImpulse))
+    .def(self_ns::str(self_ns::self))
+  ;
+
+    class_<csd::ObstacleDetectionEvent, bases<cs::SensorData>, boost::noncopyable, boost::shared_ptr<csd::ObstacleDetectionEvent>>("ObstacleDetectionEvent", no_init)
+    .add_property("actor", &csd::ObstacleDetectionEvent::GetActor)
+    .add_property("other_actor", &csd::ObstacleDetectionEvent::GetOtherActor)
+    .add_property("distance", CALL_RETURNING_COPY(csd::ObstacleDetectionEvent, GetDistance))
+    .def(self_ns::str(self_ns::self))
+  ;
+
+  class_<csd::LaneInvasionEvent, bases<cs::SensorData>, boost::noncopyable, boost::shared_ptr<csd::LaneInvasionEvent>>("LaneInvasionEvent", no_init)
+    .add_property("actor", &csd::LaneInvasionEvent::GetActor)
+    .add_property("crossed_lane_markings", CALL_RETURNING_LIST(csd::LaneInvasionEvent, GetCrossedLaneMarkings))
+    .def(self_ns::str(self_ns::self))
+  ;
+
+  class_<csd::GnssMeasurement, bases<cs::SensorData>, boost::noncopyable, boost::shared_ptr<csd::GnssMeasurement>>("GnssMeasurement", no_init)
+    .add_property("latitude", &csd::GnssMeasurement::GetLatitude)
+    .add_property("longitude", &csd::GnssMeasurement::GetLongitude)
+    .add_property("altitude", &csd::GnssMeasurement::GetAltitude)
+    .def(self_ns::str(self_ns::self))
+  ;
+
+  class_<csd::IMUMeasurement, bases<cs::SensorData>, boost::noncopyable, boost::shared_ptr<csd::IMUMeasurement>>("IMUMeasurement", no_init)
+    .add_property("accelerometer", &csd::IMUMeasurement::GetAccelerometer)
+    .add_property("gyroscope", &csd::IMUMeasurement::GetGyroscope)
+    .add_property("compass", &csd::IMUMeasurement::GetCompass)
+    .def(self_ns::str(self_ns::self))
+  ;
+
+  class_<csd::RadarMeasurement, bases<cs::SensorData>, boost::noncopyable, boost::shared_ptr<csd::RadarMeasurement>>("RadarMeasurement", no_init)
+    .add_property("raw_data", &GetRawDataAsBuffer<csd::RadarMeasurement>)
+    .def("get_detection_count", &csd::RadarMeasurement::GetDetectionAmount)
+    .def("__len__", &csd::RadarMeasurement::size)
+    .def("__iter__", iterator<csd::RadarMeasurement>())
+    .def("__getitem__", +[](const csd::RadarMeasurement &self, size_t pos) -> csd::RadarDetection {
+      return self.at(pos);
+    })
+    .def("__setitem__", +[](csd::RadarMeasurement &self, size_t pos, const csd::RadarDetection &detection) {
+      self.at(pos) = detection;
+    })
+    .def(self_ns::str(self_ns::self))
+  ;
+
+  class_<csd::RadarDetection>("RadarDetection")
+    .def_readwrite("velocity", &csd::RadarDetection::velocity)
+    .def_readwrite("azimuth", &csd::RadarDetection::azimuth)
+    .def_readwrite("altitude", &csd::RadarDetection::altitude)
+    .def_readwrite("depth", &csd::RadarDetection::depth)
+    .def(self_ns::str(self_ns::self))
+  ;
+
+  class_<csd::LidarDetection>("LidarDetection")
+    .def_readwrite("point", &csd::LidarDetection::point)
+    .def_readwrite("intensity", &csd::LidarDetection::intensity)
+    .def(self_ns::str(self_ns::self))
+  ;
+
+  class_<csd::SemanticLidarDetection>("SemanticLidarDetection")
+    .def_readwrite("point", &csd::SemanticLidarDetection::point)
+    .def_readwrite("cos_inc_angle", &csd::SemanticLidarDetection::cos_inc_angle)
+    .def_readwrite("object_idx", &csd::SemanticLidarDetection::object_idx)
+    .def_readwrite("object_tag", &csd::SemanticLidarDetection::object_tag)
+    .def(self_ns::str(self_ns::self))
+  ;
+
+  class_<csd::DVSEvent>("DVSEvent")
+    .add_property("x", &csd::DVSEvent::x)
+    .add_property("y", &csd::DVSEvent::y)
+    .add_property("t", &csd::DVSEvent::t)
+    .add_property("pol", &csd::DVSEvent::pol)
+    .def(self_ns::str(self_ns::self))
+  ;
+
+  class_<csd::DVSEventArray, bases<cs::SensorData>, boost::noncopyable, boost::shared_ptr<csd::DVSEventArray>>("DVSEventArray", no_init)
+    .add_property("width", &csd::DVSEventArray::GetWidth)
+    .add_property("height", &csd::DVSEventArray::GetHeight)
+    .add_property("fov", &csd::DVSEventArray::GetFOVAngle)
+    .add_property("raw_data", &GetRawDataAsBuffer<csd::DVSEventArray>)
+    .def("__len__", &csd::DVSEventArray::size)
+    .def("__iter__", iterator<csd::DVSEventArray>())
+    .def("__getitem__", +[](const csd::DVSEventArray &self, size_t pos) -> csd::DVSEvent {
+      return self.at(pos);
+    })
+    .def("__setitem__", +[](csd::DVSEventArray &self, size_t pos, csd::DVSEvent event) {
+      self.at(pos) = event;
+    })
+    .def("to_image", CALL_RETURNING_LIST(csd::DVSEventArray, ToImage))
+    .def("to_array", CALL_RETURNING_LIST(csd::DVSEventArray, ToArray))
+    .def("to_array_x", CALL_RETURNING_LIST(csd::DVSEventArray, ToArrayX))
+    .def("to_array_y", CALL_RETURNING_LIST(csd::DVSEventArray, ToArrayY))
+    .def("to_array_t", CALL_RETURNING_LIST(csd::DVSEventArray, ToArrayT))
+    .def("to_array_pol", CALL_RETURNING_LIST(csd::DVSEventArray, ToArrayPol))
+    .def(self_ns::str(self_ns::self))
+  ;
+
+  class_<csd::DReyeVREvent, bases<cs::SensorData>, boost::noncopyable, boost::shared_ptr<csd::DReyeVREvent>>("DReyeVREvent", no_init)
+      .add_property("timestamp_carla", CALL_RETURNING_COPY(csd::DReyeVREvent, GetTimestampCarla))
+      .add_property("timestamp_device", CALL_RETURNING_COPY(csd::DReyeVREvent, GetTimestampDevice))
+      .add_property("framesequence", CALL_RETURNING_COPY(csd::DReyeVREvent, GetFrameSequence))
+      .add_property("timestamp_stream", CALL_RETURNING_COPY(csd::DReyeVREvent, GetTimestamp)) // Stream timestamp
+      .add_property("camera_location", CALL_RETURNING_COPY(csd::DReyeVREvent, GetCameraLocation))
+      .add_property("camera_rotation", CALL_RETURNING_COPY(csd::DReyeVREvent, GetCameraRotation))
+      // combined gaze attributes
+      .add_property("gaze_dir", CALL_RETURNING_COPY(csd::DReyeVREvent, GetGazeDir))
+      .add_property("gaze_origin", CALL_RETURNING_COPY(csd::DReyeVREvent, GetGazeOrigin))
+      .add_property("gaze_valid", CALL_RETURNING_COPY(csd::DReyeVREvent, GetGazeValid))
+      .add_property("gaze_vergence", CALL_RETURNING_COPY(csd::DReyeVREvent, GetGazeVergence))
+      // left gaze attributes
+      .add_property("left_gaze_dir", CALL_RETURNING_COPY(csd::DReyeVREvent, GetLGazeDir))
+      .add_property("left_gaze_origin", CALL_RETURNING_COPY(csd::DReyeVREvent, GetLGazeOrigin))
+      .add_property("left_gaze_valid", CALL_RETURNING_COPY(csd::DReyeVREvent, GetLGazeValid))
+      .add_property("left_eye_openness", CALL_RETURNING_COPY(csd::DReyeVREvent, GetLEyeOpenness))
+      .add_property("left_eye_openness_valid", CALL_RETURNING_COPY(csd::DReyeVREvent, GetLEyeOpenValid))
+      .add_property("left_pupil_posn", CALL_RETURNING_COPY(csd::DReyeVREvent, GetLPupilPos))
+      .add_property("left_pupil_posn_valid", CALL_RETURNING_COPY(csd::DReyeVREvent, GetLPupilPosValid))
+      .add_property("left_pupil_diam", CALL_RETURNING_COPY(csd::DReyeVREvent, GetLPupilDiam))
+      // right gaze attributes
+      .add_property("right_gaze_dir", CALL_RETURNING_COPY(csd::DReyeVREvent, GetRGazeDir))
+      .add_property("right_gaze_origin", CALL_RETURNING_COPY(csd::DReyeVREvent, GetRGazeOrigin))
+      .add_property("right_gaze_valid", CALL_RETURNING_COPY(csd::DReyeVREvent, GetRGazeValid))
+      .add_property("right_eye_openness", CALL_RETURNING_COPY(csd::DReyeVREvent, GetREyeOpenness))
+      .add_property("right_eye_openness_valid", CALL_RETURNING_COPY(csd::DReyeVREvent, GetREyeOpenValid))
+      .add_property("right_pupil_posn", CALL_RETURNING_COPY(csd::DReyeVREvent, GetRPupilPos))
+      .add_property("right_pupil_posn_valid", CALL_RETURNING_COPY(csd::DReyeVREvent, GetRPupilPosValid))
+      .add_property("right_pupil_diam", CALL_RETURNING_COPY(csd::DReyeVREvent, GetRPupilDiam))
+      // focus info attributes
+      .add_property("focus_actor_name", CALL_RETURNING_COPY(csd::DReyeVREvent, GetFocusActorName))
+      .add_property("focus_actor_pt", CALL_RETURNING_COPY(csd::DReyeVREvent, GetFocusActorPoint))
+      .add_property("focus_actor_dist", CALL_RETURNING_COPY(csd::DReyeVREvent, GetFocusActorDist))
+      // user inputs attributes
+      .add_property("throttle_input", CALL_RETURNING_COPY(csd::DReyeVREvent, GetThrottle))
+      .add_property("steering_input", CALL_RETURNING_COPY(csd::DReyeVREvent, GetSteering))
+      .add_property("brake_input", CALL_RETURNING_COPY(csd::DReyeVREvent, GetBrake))
+      .add_property("current_gear_input", CALL_RETURNING_COPY(csd::DReyeVREvent, GetToggledReverse))
+      .add_property("handbrake_input", CALL_RETURNING_COPY(csd::DReyeVREvent, GetHandbrake))
+      .def(self_ns::str(self_ns::self))
+  ;
+}

--- a/Scripts/Paths/DReyeVR.csv
+++ b/Scripts/Paths/DReyeVR.csv
@@ -8,12 +8,11 @@ Content/DReyeVR_Signs/*,Unreal/CarlaUE4/Content/DReyeVR/DReyeVR_Signs/
 Content/Custom/*,Unreal/CarlaUE4/Content/DReyeVR/Custom/
 Content/Default.Package.json,Unreal/CarlaUE4/Content/Carla/Config/
 Maps/*,Unreal/CarlaUE4/Content/Carla/Maps/
-LibCarla/Sensor/data/*,LibCarla/source/carla/sensor/data/
-LibCarla/Carla/*,LibCarla/source/carla/client/
-LibCarla/Sensor/s11n/*,LibCarla/source/carla/sensor/s11n/
-LibCarla/SensorRegistry.h,LibCarla/source/carla/sensor/
-LibCarla/SensorData.cpp,PythonAPI/carla/source/libcarla/
-PythonAPI/*,PythonAPI/examples/
+LibCarla/Client/*,LibCarla/source/carla/client/
+LibCarla/Client/detail/*,LibCarla/source/carla/client/detail/
+LibCarla/Sensor/*,LibCarla/source/carla/sensor/
+PythonAPI/*.py,PythonAPI/examples/
+PythonAPI/libcarla/*,PythonAPI/carla/source/libcarla/
 Carla/*,Unreal/CarlaUE4/Plugins/Carla/Source/Carla/
 Tools/BuildTools/*.sh,Util/BuildTools/
 Tools/BuildTools/test_streaming.cpp,LibCarla/source/test/common/

--- a/Scripts/r-install.py
+++ b/Scripts/r-install.py
@@ -27,7 +27,10 @@ DOC_STRING = "Simple script to update the DReyeVR repository (reverse-install) w
 def r_install(src: str, dest: str, ROOT: str, verbose: Optional[bool] = False) -> None:
     # copy from dest into src (reverse install)
     leafname = get_leaf_from_path(src)
-    if ROOT not in dest:
+    if not os.path.exists(src):
+        raise Exception(f"Unable to locate src: \"{src}\"")
+    dest_is_root: bool = dest == os.path.dirname(dest)
+    if (not os.path.exists(dest) or dest_is_root) and ROOT not in dest:
         dest: str = advanced_join([ROOT, dest, leafname])
     if os.path.exists(dest):
         if verbose:
@@ -46,7 +49,7 @@ def r_install(src: str, dest: str, ROOT: str, verbose: Optional[bool] = False) -
             return
         elif os.path.isdir(dest):
             dest = os.path.join(dest, "*")
-        advanced_cp(dest, src)
+        advanced_cp(dest, src, verbose=verbose)
     else:
         print(f"{dest} -- not found")
 


### PR DESCRIPTION
- Fixed bug that reading the DReyeVR FRotator incorrectly swapped roll and yaw
- Removed extra prints
- Default config parameters for replay are simplified (no shaders nor extra positions)
- Fixed SpectatorScreenModeTexture in invalid locations
- Using ECC_Visibility for focus trace ignoring EgoVehicle rather than a custom ECC_GameTraceChannel4 
- Adding actor type to "name" parameter in focus info as suffix (backwards compatible)
- Fix uncommon segfault on Windows from EgoSensor initialization in EgoVehicle constructor
- Fix bug in reverse-install script that would fail on Windows rarely