### PR TITLE
install doc boost fixes

### DIFF
--- a/Docs/Install.md
+++ b/Docs/Install.md
@@ -273,11 +273,19 @@ make check CARLA=../carla
       ... PATH/TO/ANACONDA/envs/carla/bin/python3 # example output
 
       # go to carla/install dir from here
-      cd PATH/TO/ANACONDA/envs/carla/install
+      cd PATH/TO/ANACONDA/envs/carla/include
       
       # create a symlink between python3.7 -> python3.7m
       ln -s python3.7m python3.7
       ```
+
+      Install `boost_1_72_0.tar.gz` manually from https://github.com/jerry73204/carla/releases/tag/fix-boost and place file in `Build/boost_1_72_0.tar.gz`
+
+      Open `Util/BuildTools/Setup.sh` (or `Util/BuildTools/Setup.bat` on Windows)
+
+      Find the section named `Get boost` includes and comment out the `wget` lines.
+
+
       Now when you `make LibCarla` again, the `boost` errors should be resolved.
       - For more information see the bottom of this [SO post](https://stackoverflow.com/questions/42839382/failing-to-install-boost-in-python-pyconfig-h-not-found)
 

--- a/Docs/Install_Ubuntu.md
+++ b/Docs/Install_Ubuntu.md
@@ -95,3 +95,32 @@ Follow the rest of the instructions from the [tutorial](https://carla.readthedoc
 
 
 Now that you have a working CARLA 0.9.13 build, go back to the [DReyeVR installation guide](https://github.com/HARPLab/DReyeVR/blob/main/Docs/Install.md) and follow the rest of the steps to install DReyeVR on top of it.
+
+  - **READ THIS FIRST (Linux)**: You might run into a problem when compiling Boost 1.72.0 (required by `LibCarla`).
+    <details>
+
+    <summary> Show instructions to get Anaconda working on Linux </summary>
+
+    - ```bash
+      # find anaconda install:
+      which python3
+      ... PATH/TO/ANACONDA/envs/carla/bin/python3 # example output
+
+      # go to carla/install dir from here
+      cd PATH/TO/ANACONDA/envs/carla/include
+      
+      # create a symlink between python3.7 -> python3.7m
+      ln -s python3.7m python3.7
+      ```
+
+      Install `boost_1_72_0.tar.gz` manually from https://github.com/jerry73204/carla/releases/tag/fix-boost and place file in `Build/boost_1_72_0.tar.gz`
+
+      Open `Util/BuildTools/Setup.sh` (or `Util/BuildTools/Setup.bat` on Windows)
+
+      Find the section named `Get boost` includes and comment out the `wget` lines.
+
+
+      Now when you `make LibCarla` again, the `boost` errors should be resolved.
+      - For more information see the bottom of this [SO post](https://stackoverflow.com/questions/42839382/failing-to-install-boost-in-python-pyconfig-h-not-found)
+
+    </details>


### PR DESCRIPTION
Added extra steps in Docs/install.md and Docs/install_ubuntu.md to resolve common boost problems when running make PythonAPI in a conda environment when setting up carla.